### PR TITLE
Set executable

### DIFF
--- a/installer/linux/debian_package/DEBIAN/postinst
+++ b/installer/linux/debian_package/DEBIAN/postinst
@@ -1,4 +1,8 @@
 #!/bin/bash
 set -e
+
+chmod +x /etc/windscribe/update-resolv-conf /etc/windscribe/update-systemd-resolved
+chmod +x /usr/local/windscribe/windscribewstunnel
+
 systemctl enable windscribe-helper
 systemctl start windscribe-helper


### PR DESCRIPTION
Files update-resolv-conf and windscribewstunnel have to be executable otherwise there will be permission denied errors. I am guessing update-systemd-resolved probably also needs to be executable. Linux Mint doesn't use systemd-resolved, so I am not sure.
Issues #7 #6 